### PR TITLE
Attempted fix for issue #30: pre/postfix operator in closure

### DIFF
--- a/src/main/groovy/org/kohsuke/groovy/sandbox/SandboxTransformer.groovy
+++ b/src/main/groovy/org/kohsuke/groovy/sandbox/SandboxTransformer.groovy
@@ -454,7 +454,7 @@ class SandboxTransformer extends CompilationCustomizer {
                                 new ListExpression([
                                     atom,
                                     new BinaryExpression(atom, ASSIGNMENT_OP,
-                                        withLoc(atom,new MethodCallExpression(atom,op,EMPTY_ARGUMENTS)))
+                                        withLoc(atom,makeNonImplicitThisMethodCallExpression(atom,op,EMPTY_ARGUMENTS)))
                                 ]),
                                 new Token(Types.LEFT_SQUARE_BRACKET, "[", -1,-1),
                                 new ConstantExpression(0)
@@ -462,7 +462,7 @@ class SandboxTransformer extends CompilationCustomizer {
                     } else {
                         // ++a -> a=a.next()
                         return transform(withLoc(whole,new BinaryExpression(atom,ASSIGNMENT_OP,
-                                withLoc(atom,new MethodCallExpression(atom,op,EMPTY_ARGUMENTS)))
+                                withLoc(atom,makeNonImplicitThisMethodCallExpression(atom,op,EMPTY_ARGUMENTS)))
                         ));
                     }
                 } else {
@@ -489,6 +489,12 @@ class SandboxTransformer extends CompilationCustomizer {
             }
 
             return whole;
+        }
+
+        private MethodCallExpression makeNonImplicitThisMethodCallExpression(Expression objectExpression, String method, Expression arguments) {
+            MethodCallExpression exp = new MethodCallExpression(objectExpression, (Expression)(new ConstantExpression(method)), arguments);
+            exp.setImplicitThis(false);
+            return exp;
         }
 
         /**

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -150,6 +150,53 @@ class TheTest extends TestCase {
         )
     }
 
+    void testPrePostfixOperators() {
+
+        // Should work fine outside of closure with i.next() syntax
+
+        eval("""
+def i=0
+i.next()
+        """);
+
+        // Should work fine inside closure with i.next() syntax
+
+        eval("""
+def myClosure = {
+    def i=0
+    i.next()
+}
+myClosure()
+""");
+
+        // Should work fine outside of closure with i++ syntax
+        eval("""
+def i=0
+++i
+""");
+
+        // Should work fine inside of closure with i++ syntax (postfix
+
+        eval("""
+def myClosure = {
+    def i=0
+    ++i
+}
+myClosure()
+""");
+
+        // Try also postfix increment operator
+
+        eval("""
+def myClosure = {
+    def i=0
+    i++
+}
+myClosure()
+""");
+
+    }
+
     void testClosure() {
         assertIntercept(
                 "Script1\$_run_closure1.call()/Integer.class/Class:forName(String)",


### PR DESCRIPTION
When using a prefix/postfix increment operator within a closure,
construct a MethodCallExpression with a non-implicit this.
