### PR TITLE
[FIXED JENKINS-46088] Stop double-transforming casts in declarations

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
@@ -704,7 +704,7 @@ public class SandboxTransformer extends CompilationCustomizer {
                     if (mightBePositionalArgumentConstructor((VariableExpression) leftExpression)) {
                         CastExpression ce = new CastExpression(leftExpression.getType(), de.getRightExpression());
                         ce.setCoerce(true);
-                        es.setExpression(transform(new DeclarationExpression(leftExpression, de.getOperation(), transform(ce))));
+                        es.setExpression(transform(new DeclarationExpression(leftExpression, de.getOperation(), ce)));
                         return;
                     }
                 } else {

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -553,6 +553,7 @@ Exception.message
         """)
     }
 
+    @Issue("JENKINS-46088")
     void testMatcherTypeAssignment() {
         assertIntercept(
             [

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -316,7 +316,7 @@ x.plusOne(5)
      * See issue #9
      */
     void testAnd() {
-        assertIntercept('Checker:checkedCast(Class,null,Boolean,Boolean,Boolean)', false, """
+        assertIntercept('', false, """
             String s = null
             if (s != null && s.length > 0)
               throw new Exception();
@@ -550,6 +550,18 @@ Exception.message
             def x = 'foo';
             x =~ /bla/
             x ==~ /bla/
+        """)
+    }
+
+    void testMatcherTypeAssignment() {
+        assertIntercept(
+            [
+                'ScriptBytecodeAdapter:findRegex(String,String)',
+                'Matcher.matches()'
+            ],false,"""
+            def x = 'foo';
+            java.util.regex.Matcher m = x =~ /bla/
+            return m.matches()
         """)
     }
 


### PR DESCRIPTION
[JENKINS-46088](https://issues.jenkins-ci.org/browse/JENKINS-46088)

We were, well, double-transforming here. Transforming the
DeclarationExpression after adding the transformed CastExpression to
it resulted in a checkedStaticCall to Checker.checkedCast! That...was
not desirable. I believe this caused some other issues where you could
get mysterious Collections.toArray, Checker.checkedStaticCall, and
Checker.checkedCall related RejectedAccessExceptions, based on
inspecting the resulting AST from the double-transform approach.

So let's just transform the whole DeclarationExpression once. Gets us
the goal we want without the double transformation.

cc @reviewbybees 