### PR TITLE
[FIXED JENKINS-46191] Do not cast empty declarations.

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
@@ -27,6 +27,7 @@ import org.codehaus.groovy.ast.expr.ClassExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.DeclarationExpression;
+import org.codehaus.groovy.ast.expr.EmptyExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.ListExpression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
@@ -716,7 +717,9 @@ public class SandboxTransformer extends CompilationCustomizer {
                 DeclarationExpression de = (DeclarationExpression) exp;
                 Expression leftExpression = de.getLeftExpression();
                 if (leftExpression instanceof VariableExpression) {
-                    if (mightBePositionalArgumentConstructor((VariableExpression) leftExpression)) {
+                    // Only cast and transform if the RHS is *not* an EmptyExpression, i.e., "String foo;" would not be cast/transformed.
+                    if (!(de.getRightExpression() instanceof EmptyExpression) &&
+                            mightBePositionalArgumentConstructor((VariableExpression) leftExpression)) {
                         CastExpression ce = new CastExpression(leftExpression.getType(), de.getRightExpression());
                         ce.setCoerce(true);
                         es.setExpression(transform(new DeclarationExpression(leftExpression, de.getOperation(), ce)));

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -840,4 +840,15 @@ return cnt''')
                  '''
         )
     }
+
+    @Issue("JENKINS-46191")
+    void testEmptyDeclaration() {
+        assertIntercept([""],
+        "abc",
+        '''
+String a
+a = "abc"
+return a
+''')
+    }
 }


### PR DESCRIPTION
[JENKINS-46191](https://issues.jenkins-ci.org/browse/JENKINS-46191)

Before this change, "String foo;" would result in
```
BUG! exception in phase 'class generation' in source unit 'Script1.groovy' Error while popping argument from operand stack tracker in class Script1 method java.lang.Object run().
```

This is because in that scenario, the right hand side is an
`EmptyExpression`, which ends up breaking all the things when you try
to cast it to something else. So we shouldn't be trying to do a cast
at all here, and instead just transform the declaration expression
(which actually may not be needed itself, but better safe than sorry
to still transform the left hand side's variable expression, which is
basically all that will happen).

cc @reviewbybees 