### PR TITLE
[JENKINS-45982] Unwrap super call GroovyRuntimeExceptions

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -210,8 +210,12 @@ public class Checker {
                 if (chain.hasNext()) {
                     return chain.next().onSuperCall(this, s.senderType, s.receiver, method, args);
                 } else {
-                    MetaClass mc = InvokerHelper.getMetaClass(s.receiver.getClass());
-                    return mc.invokeMethod(s.senderType.getSuperclass(), s.receiver, method, args, true, true);
+                    try {
+                        MetaClass mc = InvokerHelper.getMetaClass(s.receiver.getClass());
+                        return mc.invokeMethod(s.senderType.getSuperclass(), s.receiver, method, args, true, true);
+                    } catch (GroovyRuntimeException gre) {
+                        throw ScriptBytecodeAdapter.unwrap(gre);
+                    }
                 }
             }
         }.call(s,_method,fixNull(_args));


### PR DESCRIPTION
[JENKINS-45982](https://issues.jenkins-ci.org/browse/JENKINS-45982)

Upstream of https://github.com/cloudbees/groovy-cps/pull/65

This is needed to get at the actual CpsCallableInvocation wrapped up
inside an InvokerInvocationException. This isn't an issue with
checkedCall because that ends up, via fake CallSite magic, going
through PogoMetaClassSite#call, which catches GroovyRuntimeExceptions
and unwraps them itself.

cc @reviewbybees 