### PR TITLE
[FIXED JENKINS-50380] checkedCast should just return object when assignable

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -537,7 +537,9 @@ public class Checker {
      * @see SandboxTransformer#mightBePositionalArgumentConstructor
      */
     public static Object checkedCast(Class<?> clazz, Object exp, boolean ignoreAutoboxing, boolean coerce, boolean strict) throws Throwable {
-        if (coerce && exp != null &&
+        if (exp != null && clazz != null && clazz.isAssignableFrom(exp.getClass())) {
+            return clazz.cast(exp);
+        } else if (coerce && exp != null &&
                 // Ignore some things handled by DefaultGroovyMethods.asType(Collection, Class), e.g., `[1, 2, 3] as Set` (interface → first clause) or `[1, 2, 3] as HashSet` (collection assigned to concrete class → second clause):
                 !(Collection.class.isAssignableFrom(clazz) && clazz.getPackage().getName().equals("java.util"))) {
             if (clazz.isInterface()) {

--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -537,12 +537,13 @@ public class Checker {
      * @see SandboxTransformer#mightBePositionalArgumentConstructor
      */
     public static Object checkedCast(Class<?> clazz, Object exp, boolean ignoreAutoboxing, boolean coerce, boolean strict) throws Throwable {
-        if (exp != null && clazz != null && clazz.isAssignableFrom(exp.getClass())) {
-            return clazz.cast(exp);
-        } else if (coerce && exp != null &&
+        if (coerce && exp != null &&
                 // Ignore some things handled by DefaultGroovyMethods.asType(Collection, Class), e.g., `[1, 2, 3] as Set` (interface → first clause) or `[1, 2, 3] as HashSet` (collection assigned to concrete class → second clause):
                 !(Collection.class.isAssignableFrom(clazz) && clazz.getPackage().getName().equals("java.util"))) {
-            if (clazz.isInterface()) {
+            // Don't actually cast at all if this is already assignable.
+            if (clazz.isAssignableFrom(exp.getClass())) {
+                return exp;
+            } else if (clazz.isInterface()) {
                 for (Method m : clazz.getMethods()) {
                     Object[] args = new Object[m.getParameterTypes().length];
                     for (int i = 0; i < args.length; i++) {

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -869,4 +869,16 @@ def s = []
 s.join(' ')
 """)
     }
+
+    @Issue("JENKINS-50380")
+    void testCheckedCastWhenAssignable() {
+        assertIntercept(['new NonArrayConstructorList(Boolean,Boolean)',
+                         'NonArrayConstructorList.join(String)'],
+            "one",
+            '''
+NonArrayConstructorList foo = new NonArrayConstructorList(true, false)
+List castFoo = (List)foo
+return castFoo.join('')
+''')
+    }
 }

--- a/src/test/java/org/kohsuke/groovy/sandbox/NonArrayConstructorList.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/NonArrayConstructorList.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.kohsuke.groovy.sandbox;
+
+
+import java.util.ArrayList;
+
+/**
+ * Used in {@link TheTest#testCheckedCastWhenAssignable()} - couldn't be an inner class due to gmaven issues.
+ */
+public class NonArrayConstructorList extends ArrayList<String> {
+    public NonArrayConstructorList(boolean choiceOne, boolean choiceTwo) {
+        if (choiceOne) {
+            this.add("one");
+        }
+        if (choiceTwo) {
+            this.add("two");
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-50380](https://issues.jenkins-ci.org/browse/JENKINS-50380)

Without this, we end up doing some silly stuff like actually turning `Foo f = new Foo()` into `Foo f = DefaultTypeTransformation.castToType(Foo.class, new Foo())`, and even weirder stuff with `Collection`s that aren't in `java.util`. The latter get particularly messed up if for some reason, the `Collection` class doesn't have a `SomeCollection(Object[])` constructor.

So let's avoid the silliness of actually going through with emulating `DefaultTypeTransformation.castToType` and just ~~use `clazz.cast`~~ return the object when the object is assignable to the class.

cc @reviewbybees 