### PR TITLE
[JENKINS-50470] Treat checkedGetProperty for collection as spread

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -246,7 +246,7 @@ public class Checker {
     public static Object checkedGetProperty(final Object _receiver, boolean safe, boolean spread, Object _property) throws Throwable {
         if (safe && _receiver==null)     return null;
 
-        if (spread) {
+        if (spread || _receiver instanceof Collection) {
             List<Object> r = new ArrayList<Object>();
             Iterator itr = InvokerHelper.asIterator(_receiver);
             while (itr.hasNext()) {

--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -246,7 +246,7 @@ public class Checker {
     public static Object checkedGetProperty(final Object _receiver, boolean safe, boolean spread, Object _property) throws Throwable {
         if (safe && _receiver==null)     return null;
 
-        if (spread || _receiver instanceof Collection) {
+        if (spread || (_receiver instanceof Collection && !BUILTIN_PROPERTIES.contains(_property))) {
             List<Object> r = new ArrayList<Object>();
             Iterator itr = InvokerHelper.asIterator(_receiver);
             while (itr.hasNext()) {

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -881,4 +881,22 @@ List castFoo = (List)foo
 return castFoo.join('')
 ''')
     }
+
+    @Issue("JENKINS-50470")
+    void testCollectionGetProperty() {
+        assertIntercept(['new SimpleNamedBean(String)',
+                         'new SimpleNamedBean(String)',
+                         'new SimpleNamedBean(String)',
+                         // Before the JENKINS-50470 fix, this would just be ArrayList.name
+                         'SimpleNamedBean.name',
+                         'SimpleNamedBean.name',
+                         'SimpleNamedBean.name',
+                         'ArrayList.join(String)'],
+            "abc",
+        '''
+def l = [new SimpleNamedBean("a"), new SimpleNamedBean("b"), new SimpleNamedBean("c")]
+def nameList = l.name
+return nameList.join('')
+''')
+    }
 }

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -891,12 +891,16 @@ return castFoo.join('')
                          'SimpleNamedBean.name',
                          'SimpleNamedBean.name',
                          'SimpleNamedBean.name',
-                         'ArrayList.join(String)'],
-            "abc",
+                         'ArrayList.class',
+                         'ArrayList.join(String)',
+                         'String.plus(String)',
+                         'String.plus(Class)'],
+            "abc class java.util.ArrayList",
         '''
 def l = [new SimpleNamedBean("a"), new SimpleNamedBean("b"), new SimpleNamedBean("c")]
 def nameList = l.name
-return nameList.join('')
+def cl = l.class
+return nameList.join('') + ' ' + cl
 ''')
     }
 }

--- a/src/test/java/org/kohsuke/groovy/sandbox/SimpleNamedBean.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SimpleNamedBean.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.kohsuke.groovy.sandbox;
+
+public class SimpleNamedBean {
+    private String name;
+
+    public SimpleNamedBean(String n) {
+        this.name = n;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
[JENKINS-50470](https://issues.jenkins-ci.org/browse/JENKINS-50470)

This is how Groovy's own MetaClassImpl.getProperty works for Collections, so we should do the same thing.

Note that we can't actually replicate the error case in groovy-sandbox tests, just the bad interceptor trace. The actual testing of the error case is downstream in script-security.

@reviewbybees 

