### PR TITLE
added getter/setter for SandboxTransformer properties

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
@@ -314,6 +314,46 @@ public class SandboxTransformer extends CompilationCustomizer {
         return new VisitorImpl(source, clazz);
     }
 
+    public boolean isInterceptMethodCall() {
+        return interceptMethodCall;
+    }
+
+    public void setInterceptMethodCall(boolean interceptMethodCall) {
+        this.interceptMethodCall = interceptMethodCall;
+    }
+
+    public boolean isInterceptConstructor() {
+        return interceptConstructor;
+    }
+
+    public void setInterceptConstructor(boolean interceptConstructor) {
+        this.interceptConstructor = interceptConstructor;
+    }
+
+    public boolean isInterceptProperty() {
+        return interceptProperty;
+    }
+
+    public void setInterceptProperty(boolean interceptProperty) {
+        this.interceptProperty = interceptProperty;
+    }
+
+    public boolean isInterceptArray() {
+        return interceptArray;
+    }
+
+    public void setInterceptArray(boolean interceptArray) {
+        this.interceptArray = interceptArray;
+    }
+
+    public boolean isInterceptAttribute() {
+        return interceptAttribute;
+    }
+
+    public void setInterceptAttribute(boolean interceptAttribute) {
+        this.interceptAttribute = interceptAttribute;
+    }
+
     class VisitorImpl extends ScopeTrackingClassCodeExpressionTransformer {
         private final SourceUnit sourceUnit;
         /**


### PR DESCRIPTION
After upgrading from 1.6 we noticed that it's not possible anymore to set the SandboxTransformer properties this change introduces getters and setters for them.