### PR TITLE
Prevent exception from being thrown when calling sandbox-defined varargs constructors

### DIFF
--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -480,4 +480,28 @@ public class SandboxTransformerTest {
         }
     }
 
+    @Test public void constructorWithVarArgs() throws Exception {
+        assertIntercept(
+                "def result = []\n" +
+                "class Test {\n" +
+                "  Test(List<Integer> result, Integer... vals) {\n" +
+                "    result.add(vals.sum())\n" +
+                "  }\n" +
+                "}\n" +
+                "new Test(result, 1)\n" +
+                "new Test(result, 2, 3)\n" +
+                "new Test(result)\n" +
+                "result",
+                Arrays.asList(1, 5, null),
+                "new Test(ArrayList,Integer)",
+                "Integer[].sum()",
+                "ArrayList.add(Integer)",
+                "new Test(ArrayList,Integer,Integer)",
+                "Integer[].sum()",
+                "ArrayList.add(Integer)",
+                "new Test(ArrayList)",
+                "Integer[].sum()",
+                "ArrayList.add(null)");
+    }
+
 }


### PR DESCRIPTION
Fixes #67, which was caused by the fix for SECURITY-1754.

Just opening a quick draft PR for now showing how the problem could be fixed. We would need to do some more testing to make sure the change doesn't break the security fix before it could be merged.