### PR TITLE
Bump Groovy from 2.4.12 to 2.4.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.4.12</version> <!-- Note: Do not update past 2.4.12 unless Jenkins core is updated to use a newer version of Groovy. -->
+      <version>2.4.21</version> <!-- Note: Do not update past 2.4.12 unless Jenkins core is updated to use a newer version of Groovy. -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.4.21</version> <!-- Note: Do not update past 2.4.12 unless Jenkins core is updated to use a newer version of Groovy. -->
+      <version>2.4.21</version> <!-- Note: Do not update past this version unless Jenkins core is updated to use a newer version of Groovy. -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Not for review. Filing for testing purposes. Timestamped snapshots built locally (with passing tests!) available at:

https://repo.jenkins-ci.org/snapshots/org/kohsuke/groovy-sandbox/1.28-SNAPSHOT/