### PR TITLE
Demonstrating GROOVY-9608 method interception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.4.12</version> <!-- Note: Do not update past 2.4.12 unless Jenkins core is updated to use a newer version of Groovy. -->
+      <version>2.4.21</version> <!-- Note: Do not update past 2.4.12 unless Jenkins core is updated to use a newer version of Groovy. -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -937,8 +937,9 @@ return nameList.join('') + ' ' + cl
         assertIntercept(['new B()',
                          'new A()',
                          'B.metaClass',
-                         'HandleMetaClass.getAttribute(Class,B,String,Boolean)'],
-                "B",
+                         'HandleMetaClass.getAttribute(Class,B,String,Boolean)',
+                         'MissingFieldException.message'],
+                "No such field: x for class: A",
                 '''
             class A {
               public x = 'A'
@@ -947,13 +948,18 @@ return nameList.join('') + ' ' + cl
               public x = 'B'
             }
             def b = new B()
-            def bSuperX = b.metaClass.getAttribute(A, b, 'x', true)
-            return bSuperX
-            ''')
+            try {
+                def bSuperX = b.metaClass.getAttribute(A, b, 'x', true)
+                return bSuperX
+            } catch (MissingFieldException e) {
+                return e.message
+                // TODO: Why can't these read public/protected field from super?
+            }''')
         assertIntercept(['new B()',
                          'new A()',
-                         'ScriptBytecodeAdapter:getFieldOnSuper(Class,B,String)'],
-                "B",
+                         'ScriptBytecodeAdapter:getFieldOnSuper(Class,B,String)',
+                         'MissingFieldException.message'],
+                "No such field: x for class: A",
                 '''
             import org.codehaus.groovy.runtime.ScriptBytecodeAdapter
             class A {
@@ -963,8 +969,12 @@ return nameList.join('') + ' ' + cl
               public x = 'B'
             }
             def b = new B()
-            def bSuperX = ScriptBytecodeAdapter.getFieldOnSuper(A, b, 'x')
-            return bSuperX
-            ''')
+            try {
+                def bSuperX = ScriptBytecodeAdapter.getFieldOnSuper(A, b, 'x')
+                return bSuperX
+            } catch (MissingFieldException e) {
+                return e.message
+                // TODO: Why can't these read public/protected field from super?
+            }''')
     }
 }

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -903,4 +903,68 @@ def cl = l.class
 return nameList.join('') + ' ' + cl
 ''')
     }
+
+    @Issue("JENKINS-65237")
+    void testGetFieldOnSuper() {
+        assertIntercept(['new A()',
+                         'A.metaClass',
+                         'HandleMetaClass.getAttribute(Class,A,String,Boolean)'],
+                "A",
+                '''
+            class A {
+              public x = 'A'
+            }
+            def a = new A()
+            def ax = a.metaClass.getAttribute(A, a, 'x', false)
+            return ax
+            ''')
+        assertIntercept(['new B()',
+                         'new A()',
+                         'B.metaClass',
+                         'HandleMetaClass.getAttribute(Class,B,String,Boolean)'],
+                "B",
+                '''
+            class A {
+              public x = 'A'
+            }
+            class B extends A {
+              public x = 'B'
+            }
+            def b = new B()
+            def bx = b.metaClass.getAttribute(B, b, 'x', false)
+            return bx
+            ''')
+        assertIntercept(['new B()',
+                         'new A()',
+                         'B.metaClass',
+                         'HandleMetaClass.getAttribute(Class,B,String,Boolean)'],
+                "B",
+                '''
+            class A {
+              public x = 'A'
+            }
+            class B extends A {
+              public x = 'B'
+            }
+            def b = new B()
+            def bSuperX = b.metaClass.getAttribute(A, b, 'x', true)
+            return bSuperX
+            ''')
+        assertIntercept(['new B()',
+                         'new A()',
+                         'ScriptBytecodeAdapter:getFieldOnSuper(Class,B,String)'],
+                "B",
+                '''
+            import org.codehaus.groovy.runtime.ScriptBytecodeAdapter
+            class A {
+              public x = 'A'
+            }
+            class B extends A {
+              public x = 'B'
+            }
+            def b = new B()
+            def bSuperX = ScriptBytecodeAdapter.getFieldOnSuper(A, b, 'x')
+            return bSuperX
+            ''')
+    }
 }


### PR DESCRIPTION
Demonstrating that apache/groovy@cf51a3f fixes [GROOVY-9608](https://issues.apache.org/jira/browse/GROOVY-9608) without altering method interception.