### PR TITLE
Switch parent POM to org.jenkins-ci:jenkins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+tag-template: groovy-sandbox-$NEXT_MINOR_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - master
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,24 +1,4 @@
-pipeline {
-    options {
-        buildDiscarder(logRotator(numToKeepStr: '20'))
-        timeout(time: 1, unit: 'HOURS')
-    }
-    agent {
-        docker {
-            image 'maven:3.5.0-jdk-8'
-            label 'docker'
-        }
-    }
-    stages {
-        stage('main') {
-            steps {
-                sh 'mvn -B clean verify'
-            }
-            post {
-                success {
-                    junit '**/target/surefire-reports/TEST-*.xml'
-                }
-            }
-        }
-    }
-}
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '17' ],
+  [ platform: 'windows', jdk: '8' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.kohsuke</groupId>
-    <artifactId>pom</artifactId>
-    <version>21</version>
+    <groupId>org.jenkins-ci</groupId>
+    <artifactId>jenkins</artifactId>
+    <version>1.76</version>
     <relativePath />
   </parent>
 
@@ -18,11 +18,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revision>1.28</revision>
     <changelist>-SNAPSHOT</changelist>
-    <!-- TODO: Move these three properties to the parent POM or use org.jenkins-ci:jenkins as the parent POM here -->
-    <incrementals-enforce-minimum.version>1.1</incrementals-enforce-minimum.version>
-    <incrementals-plugin.version>1.1</incrementals-plugin.version>
-    <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
+    <!-- We throw Exception/Throwable in many places due to the nature of this library, and this visitor will be disabled by default in an upcoming SpotBugs release anyway, see https://github.com/spotbugs/spotbugs/issues/2040. -->
+    <spotbugs.omitVisitors>ThrowingExceptions</spotbugs.omitVisitors>
   </properties>
 
   <repositories>
@@ -40,67 +38,38 @@
   </pluginRepositories>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>io.jenkins.tools.incrementals</groupId>
-          <artifactId>incrementals-maven-plugin</artifactId>
-          <version>${incrementals-plugin.version}</version>
-          <configuration>
-            <includes>
-              <include>org.jenkins-ci.*</include>
-              <include>io.jenkins.*</include>
-            </includes>
-            <generateBackupPoms>false</generateBackupPoms>
-            <updateNonincremental>false</updateNonincremental>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.5-jenkins-3</version>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.13.1</version>
         <executions>
           <execution>
             <goals>
+              <goal>addTestSources</goal>
               <goal>generateTestStubs</goal>
-              <goal>testCompile</goal>
+              <goal>compileTests</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-           <providerSelection>1.8</providerSelection>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-1.8</artifactId>
-            <version>1.5-jenkins-3</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>
         <executions>
           <execution>
             <goals>
-              <goal>test-jar</goal>
+              <goal>test-jar</goal> <!-- ClassRecorder is used by groovy-cps -->
             </goals>
             <phase>package</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <releaseProfiles>release</releaseProfiles>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -114,13 +83,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
-      <version>1.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -132,123 +99,25 @@
     <tag>${scmTag}</tag>
   </scm>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
-
-  <!-- TODO: Move these profiles to the parent POM or use org.jenkins-ci:jenkins as the parent POM here -->
   <profiles>
-    <profile> <!-- see JEP-305 -->
-      <id>consume-incrementals</id>
-      <repositories>
-        <repository>
-          <id>incrementals</id>
-          <url>${incrementals.url}</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>incrementals</id>
-          <url>${incrementals.url}</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
     <profile>
-      <id>might-produce-incrementals</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>flatten-maven-plugin</artifactId>
-            <version>1.0.1</version>
-            <configuration>
-              <updatePomFile>true</updatePomFile>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
-            </configuration>
-            <executions>
-              <execution>
-                <id>flatten</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>flatten</goal>
-                </goals>
-                <configuration>
-                    <flattenMode>oss</flattenMode>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.0.0-M2</version>
-            <executions>
-              <execution>
-                <id>display-info</id>
-                <configuration>
-                  <rules>
-                    <requireMavenVersion>
-                      <version>[3.5.4,)</version>
-                      <message>3.5.4+ required to use Incrementals.</message>
-                    </requireMavenVersion>
-                    <rule implementation="io.jenkins.tools.incrementals.enforcer.RequireExtensionVersion">
-                      <version>[${incrementals-enforce-minimum.version},)</version>
-                    </rule>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>io.jenkins.tools.incrementals</groupId>
-                <artifactId>incrementals-enforcer-rules</artifactId>
-                <version>${incrementals-plugin.version}</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-          <plugin>
-            <artifactId>maven-release-plugin</artifactId>
-            <configuration>
-              <completionGoals>incrementals:reincrementalify</completionGoals>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>produce-incrementals</id>
-      <activation>
-        <property>
-          <name>set.changelist</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <distributionManagement>
-        <repository>
-          <id>incrementals</id>
-          <url>${incrementals.url}</url>
-        </repository>
-      </distributionManagement>
+      <id>release</id>
       <build>
         <plugins>
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>2.1.2</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>attach-test-sources</id>
+                <goals>
+                  <goal>test-jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revision>1.28</revision>
     <changelist>-SNAPSHOT</changelist>
-    <scmTag>HEAD</scmTag>
+    <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <!-- We throw Exception/Throwable in many places due to the nature of this library, and this visitor will be disabled by default in an upcoming SpotBugs release anyway, see https://github.com/spotbugs/spotbugs/issues/2040. -->
     <spotbugs.omitVisitors>ThrowingExceptions</spotbugs.omitVisitors>
   </properties>
@@ -94,9 +94,9 @@
   </dependencies>
 
   <scm>
-    <connection>scm:git:git@github.com/jenkinsci/${project.artifactId}.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}.git</developerConnection>
-    <url>http://${project.artifactId}.kohsuke.org/</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <relativePath />
   </parent>
 
+  <groupId>org.kohsuke</groupId>
   <artifactId>groovy-sandbox</artifactId>
   <version>${revision}${changelist}</version>
 

--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -579,7 +579,7 @@ public class Checker {
     public static Object checkedComparison(Object lhs, final int op, Object rhs) throws Throwable {
         if (lhs==null) {// bypass the checker if lhs is null, as it will not result in any calls that will require protection anyway
             return InvokerHelper.invokeStaticMethod(ScriptBytecodeAdapter.class,
-                    Ops.binaryOperatorMethods(op), new Object[]{lhs,rhs});
+                    Ops.binaryOperatorMethods(op), new Object[]{null, rhs});
         }
 
         return new SingleArgInvokerChain(lhs) {


### PR DESCRIPTION
This library is currently configured to release to Maven central using Kohsuke's parent POM, but for the past 4 years or so, it has only been released as part of a Jenkins security fix directly to https://repo.jenkins-ci.org/ (note that in https://github.com/jenkinsci/groovy-sandbox/pull/63 we updated the README to explicitly discourage use of this library outside of Jenkins). This PR changes the parent POM to https://github.com/jenkinsci/pom so that we can release this library to https://repo.jenkins-ci.org/ under normal circumstances.

I will also file a PR to https://github.com/jenkins-infra/repository-permissions-updater to set up this libary.

Eventually I would like to turn https://github.com/jenkinsci-cert/script-security-plugin into a multi-module project with this library as one of the submodules, but I want to do things one step at a time.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
