### PR TITLE
Update pom.xml and dependabot.yml to minimize Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # groovy version needs to track Jenkins core, see pom.xml.
+      - dependency-name: "org.codehaus.groovy:groovy"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.1</version>
+    <version>1.3</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <goals>
@@ -107,7 +106,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.1.2</version>
             <executions>
               <execution>
                 <id>attach-sources</id>


### PR DESCRIPTION
#79 and #80 are caused by unnecessary specification of plugin versions which are already controlled by `pluginManagement` in the parent POM.

We never want Dependabot to try to update Groovy as in #78.

#81 is fine but I went ahead and updated it here anyway.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
