### PR TITLE
Add a test for sandbox-transformed constructors with varargs parameters

### DIFF
--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -1078,4 +1078,29 @@ public class SandboxTransformerTest {
         assertIntercept("@groovy.transform.Field String x; x = null", null);
     }
 
+    @Test
+    public void sandboxSupportsConstructorsWithVarArgs() throws Exception {
+        assertIntercept(
+                "def result = []\n" +
+                "class Test {\n" +
+                "  Test(List<Integer> result, Integer... vals) {\n" +
+                "    result.add(vals.sum())\n" +
+                "  }\n" +
+                "}\n" +
+                "new Test(result, 1)\n" +
+                "new Test(result, 2, 3)\n" +
+                "new Test(result)\n" +
+                "result",
+                Arrays.asList(1, 5, null),
+                "new Test(ArrayList,Integer)",
+                "Integer[].sum()",
+                "ArrayList.add(Integer)",
+                "new Test(ArrayList,Integer,Integer)",
+                "Integer[].sum()",
+                "ArrayList.add(Integer)",
+                "new Test(ArrayList)",
+                "Integer[].sum()",
+                "ArrayList.add(null)");
+    }
+
 }


### PR DESCRIPTION
https://github.com/jenkinsci/groovy-sandbox/commit/520243213bcd8c81322e8e683daa8d555bb4f484 fixed #67 (the problematic `isIllegalCallToSyntheticConstructor` method has been deleted and the relevant logic has been modified). This PR just adds a test case to prevent future regressions.
