### PR TITLE
Fix interception of return statements in closures

### DIFF
--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -1103,4 +1103,32 @@ public class SandboxTransformerTest {
                 "ArrayList.add(null)");
     }
 
+    @Test
+    public void sandboxSupportsReturnStatementsInClosures() throws Exception {
+        assertIntercept(
+                "@groovy.transform.Field\n" +
+                "private static final field = [\n" +
+                "  key: { x -> return x == 123 }\n" +
+                "]\n" +
+                "field.key(123)\n",
+                true,
+                "Script1.field",
+                "LinkedHashMap.key(Integer)",
+                "Integer.compareTo(Integer)");
+        assertIntercept(
+                "File method() {\n" +
+                "  def field = [\n" +
+                "    key: { x -> return x }\n" +
+                "  ]\n" +
+                "  result = field.key(['secret.key'])\n" +
+                "  null\n" +
+                "}\n" +
+                "method()\n" +
+                "result",
+                Arrays.asList("secret.key"),
+                "Script2.method()",
+                "LinkedHashMap.key(ArrayList)",
+                "Script2.result=ArrayList",
+                "Script2.result");
+    }
 }


### PR DESCRIPTION
Fixes #99

The code related to intercepting implicit Groovy casts in method return values in https://github.com/jenkinsci/groovy-sandbox/commit/520243213bcd8c81322e8e683daa8d555bb4f484 caused two related bugs for closure expressions with explicit return statements:

1. Closures that are not inside of a method (e.g. they are defined using `@Field`) and have explicit return statements cause an NPE during compilation
2. For Closures that are inside of a method and have explicit return statements, the sandbox transforms the return statement and inserts a checked cast to the return type of the surrounding method, which is incorrect

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
