### PR TITLE
[JENKINS-70080] Do not generate invalid bytecode for field assignments that use compound operators

### DIFF
--- a/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/SandboxTransformer.java
@@ -684,7 +684,7 @@ public class SandboxTransformer extends CompilationCustomizer {
                                     // reflection to assign values to final fields in constructors and initializers
                                     // and to prevent infinite loops in setter methods.
                                     Token op = be.getOperation();
-                                    if (be.getOperation().getType() == Types.ASSIGN) {
+                                    if (op.getType() == Types.ASSIGN) {
                                         return new BinaryExpression(new FieldExpression(field), op,
                                             makeCheckedGroovyCast(field.getType(), transform(be.getRightExpression())));
                                     } else {

--- a/src/main/java/org/kohsuke/groovy/sandbox/ScopeTrackingClassCodeExpressionTransformer.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/ScopeTrackingClassCodeExpressionTransformer.java
@@ -111,6 +111,8 @@ abstract class ScopeTrackingClassCodeExpressionTransformer extends ClassCodeExpr
                 // When using Java-style for loops, the 3 expressions are a ClosureListExpression and ForStatement.getVariable is a dummy value that we need to ignore.
                 declareVariable(forLoop.getVariable());
             }
+            // Avoid super.visitForLoop because it transforms the collection expression but then recurses on the entire
+            // ForStatement, causing the collection expression to be visited a second time.
             forLoop.setCollectionExpression(transform(forLoop.getCollectionExpression()));
             forLoop.getLoopBlock().visit(this);
         }
@@ -138,6 +140,8 @@ abstract class ScopeTrackingClassCodeExpressionTransformer extends ClassCodeExpr
 
     @Override
     public void visitSynchronizedStatement(SynchronizedStatement sync) {
+        // Avoid super.visitSynchronizedStatement because it transforms the expression but then recurses on the entire
+        // SynchronizedStatement, causing the expression to be visited a second time.
         sync.setExpression(transform(sync.getExpression()));
         try (StackVariableSet scope = new StackVariableSet(this)) {
             sync.getCode().visit(this);
@@ -161,6 +165,8 @@ abstract class ScopeTrackingClassCodeExpressionTransformer extends ClassCodeExpr
 
     @Override
     public void visitWhileLoop(WhileStatement loop) {
+        // Avoid super.visitWhileLoop because it transforms the boolean expression but then recurses on the entire
+        // WhileStatement, causing the boolean expression to be visited a second time.
         loop.setBooleanExpression((BooleanExpression) transform(loop.getBooleanExpression()));
         try (StackVariableSet scope = new StackVariableSet(this)) {
             loop.getLoopBlock().visit(this);

--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -1131,4 +1131,93 @@ public class SandboxTransformerTest {
                 "Script2.result=ArrayList",
                 "Script2.result");
     }
+
+    @Test
+    public void sandboxSupportsFinalFields() {
+        assertIntercept(
+                "class Test {\n" +
+                "  final String p\n" +
+                "  Test() {\n" +
+                "    p = 'value'\n" +
+                "  }\n" +
+                "}\n" +
+                "new Test().p",
+                "value",
+                // Intercepted operations:
+                "new Test()",
+                "Test.p");
+    }
+
+    @Test
+    public void sandboxDoesNotRecurseInfinitelyInSetters() {
+        assertIntercept(
+                "class Test {\n" +
+                "  String prop\n" +
+                "  def setProp(newProp) {\n" +
+                "    prop = newProp\n" +
+                "    prop\n" +
+                "  }\n" +
+                "}\n" +
+                "new Test().prop = 'value'",
+                "value",
+                // Intercepted operations:
+                "new Test()",
+                "Test.prop=String",
+                "Test.prop");
+    }
+
+    @Test
+    public void sandboxDoesNotPerformImplicitCastsForOverloadedOperators() {
+        // groovy.lang.MissingMethodException: No signature of method: OverridePlus.plus() is applicable for argument types: (java.util.ArrayList) values: [[secret.key]]
+        assertFailsWithSameException(
+                "class OverridePlus {\n" +
+                "  def file\n" +
+                "  OverridePlus plus(File file) {\n" +
+                "    this.file = file\n" +
+                "    this\n" +
+                "  }\n" +
+                "}\n" +
+                "new OverridePlus() + ['secret.key']\n");
+    }
+
+    @Issue("JENKINS-70080")
+    @Test
+    public void sandboxSupportsCompoundAssignmentsToFields() throws Throwable {
+        assertIntercept(
+                "class Test {\n" +
+                "  def map = [:]\n" +
+                "  def add(newMap) {\n" +
+                "    map += newMap\n" +
+                "    map\n" +
+                "  }\n" +
+                "}\n" +
+                "new Test().add([k: 'v'])\n",
+                Collections.singletonMap("k", "v"),
+                // Intercepted operations:
+                "new Test()",
+                "Test.add(LinkedHashMap)",
+                "LinkedHashMap.plus(LinkedHashMap)",
+                "Test.map");
+        assertIntercept(
+                "class Test {\n" +
+                "  final Map map = [:]\n" +
+                "  Test(newMap) {\n" +
+                "    map += newMap\n" + // Groovy is more lenient with 'final' than Java
+                "  }\n" +
+                "}\n" +
+                "new Test([k: 'v']).map\n",
+                Collections.singletonMap("k", "v"),
+                // Intercepted operations:
+                "new Test(LinkedHashMap)",
+                "LinkedHashMap.plus(LinkedHashMap)",
+                "Test.map");
+        assertFailsWithSameException(
+                "class Test {\n" +
+                "  final Map map\n" +
+                "  Test(newMap) {\n" +
+                "    map += newMap\n" + // java.lang.NullPointerException: Cannot execute null+{}
+                "  }\n" +
+                "}\n" +
+                "new Test([:]).map\n");
+    }
 }


### PR DESCRIPTION
See [JENKINS-70080](https://issues.jenkins.io/browse/JENKINS-70080).

The SECURITY-2824 fix (520243213bcd8c81322e8e683daa8d555bb4f484) inadvertently caused sandbox-transformed field assignments that use compound operators to generate invalid bytecode.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
