### PR TITLE
Update plugin parent POM to latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '17' ],
-  [ platform: 'windows', jdk: '8' ],
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.49</version>
+    <version>4.60</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Also switches the Windows build from Java 8 to Java 11, since this is the minimum Java version supported by the latest parent POM.