### PR TITLE
Fix handling of `null` with spread operator and improve test suite using mutation testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Run mvn test-compile org.pitest:pitest-maven:mutationCoverage to generate a mutation coverage report. -->
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
         <version>1.15.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,25 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.15.0</version>
+        <configuration>
+          <verbose>true</verbose>
+          <outputFormats>
+            <outputFormat>HTML</outputFormat>
+            <outputFormat>XML</outputFormat>
+          </outputFormats>
+          <historyInputFile>${project.build.directory}/pit-history.bin</historyInputFile>
+          <historyOutputFile>${project.build.directory}/pit-history.bin</historyOutputFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>

--- a/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
+++ b/src/main/java/org/kohsuke/groovy/sandbox/impl/Checker.java
@@ -70,8 +70,11 @@ public class Checker {
             Iterator itr = InvokerHelper.asIterator(_receiver);
             while (itr.hasNext()) {
                 Object it = itr.next();
-                if (it!=null)
+                if (it!=null) {
                     r.add(checkedCall(it, true, false, _method, _args));
+                } else {
+                    r.add(null);
+                }
             }
             return r;
         } else {

--- a/src/test/java/org/kohsuke/groovy/sandbox/AbstractSandboxTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/AbstractSandboxTest.java
@@ -1,0 +1,225 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.kohsuke.groovy.sandbox;
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
+import org.kohsuke.groovy.sandbox.impl.GroovyCallSiteSelector;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.matchesPattern;
+
+/**
+ * Abstract base class for sandbox testing that provides common utility methods and setup code.
+ */
+public abstract class AbstractSandboxTest {
+    public @Rule ErrorCollector ec = new ErrorCollector();
+    public Binding binding = new Binding();
+    public GroovyShell sandboxedSh;
+    public GroovyShell unsandboxedSh;
+    public ClassRecorder cr = new ClassRecorder();
+
+    @Before
+    public void setUp() {
+        CompilerConfiguration cc = new CompilerConfiguration();
+        cc.addCompilationCustomizers(new ImportCustomizer().addImports(getClass().getName()).addStarImports("org.kohsuke.groovy.sandbox"));
+        cc.addCompilationCustomizers(new SandboxTransformer());
+        sandboxedSh = new GroovyShell(binding, cc);
+
+        cc = new CompilerConfiguration();
+        cc.addCompilationCustomizers(new ImportCustomizer().addImports(getClass().getName()).addStarImports("org.kohsuke.groovy.sandbox"));
+        unsandboxedSh = new GroovyShell(binding, cc);
+    }
+
+    public void configureBinding() { }
+
+    /**
+     * Use {@code ShouldFail.class} as the expected result for {@link #sandboxedEval} and {@link #unsandboxedEval}
+     * when the expression is expected to throw an exception.
+     */
+    public static final class ShouldFail { }
+
+    @FunctionalInterface
+    public interface ExceptionHandler {
+        public void handleException(Throwable e) throws Exception;
+    }
+
+    /**
+     * Executes a Groovy expression inside of the sandbox.
+     * @param expression The Groovy expression to execute.
+     */
+    public void sandboxedEval(String expression, Object expectedResult, ExceptionHandler handler) {
+        cr.reset();
+        cr.register();
+        try {
+            configureBinding();
+            Object actual = sandboxedSh.evaluate(expression);
+            String actualType = GroovyCallSiteSelector.getName(actual);
+            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
+            ec.checkThat("Sandboxed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
+        } catch (Throwable e) {
+            ec.checkSucceeds(() -> {
+                try {
+                    handler.handleException(e);
+                } catch (Throwable t) {
+                    t.addSuppressed(e); // Keep the original error around in case an assertion fails in the handler.
+                    throw t;
+                }
+                return null;
+            });
+        } finally {
+            cr.unregister();
+        }
+    }
+
+    /**
+     * Executes a Groovy expression outside of the sandbox.
+     * @param expression The Groovy expression to execute.
+     */
+    protected void unsandboxedEval(String expression, Object expectedResult, ExceptionHandler handler) {
+        try {
+            configureBinding();
+            Object actual = unsandboxedSh.evaluate(expression);
+            String actualType = GroovyCallSiteSelector.getName(actual);
+            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
+            ec.checkThat("Unsandboxed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
+        } catch (Exception e) {
+            ec.checkSucceeds(() -> {
+                handler.handleException(e);
+                return null;
+            });
+        }
+    }
+
+    /**
+     * Execute a Groovy expression both in and out of the sandbox and check that the return value matches the
+     * expected value and that the given list of method calls are intercepted by the sandbox.
+     * @param expression The Groovy expression to execute.
+     * @param expectedReturnValue The expected return value for running the script.
+     * @param expectedCalls The method calls that are expected to be intercepted by the sandbox.
+     */
+    public void assertIntercept(String expression, Object expectedReturnValue, String... expectedCalls) {
+        assertEvaluate(expression, expectedReturnValue);
+        assertIntercepted(expectedCalls);
+    }
+
+    /**
+     * Check that the most recently executed expression intercepted the expected calls.
+     * Automatically adds {@code new Script(Binding)} to the list of intercepted calls.
+     * @param expectedCalls The method calls that were expected to be intercepted by the sandbox.
+     * @see #assertInterceptedExact
+     */
+    public void assertIntercepted(String... expectedCalls) {
+        // Workaround to avoid having to update all existing tests.
+        String[] updatedExpectedCalls = expectedCalls;
+        if (expectedCalls.length == 0 || (expectedCalls.length > 0 && !expectedCalls[0].equals("new Script(Binding)"))) {
+            updatedExpectedCalls = new String[expectedCalls.length + 1];
+            updatedExpectedCalls[0] = "new Script(Binding)";
+            System.arraycopy(expectedCalls, 0, updatedExpectedCalls, 1, expectedCalls.length);
+        }
+        assertInterceptedExact(updatedExpectedCalls);
+    }
+
+    /**
+     * Check that the most recently executed expression intercepted the expected calls.
+     * @param expectedCalls The method calls that were expected to be intercepted by the sandbox.
+     */
+    @SuppressWarnings("unchecked")
+    public void assertInterceptedExact(String... expectedCalls) {
+        String[] interceptedCalls = cr.toString().split("\n");
+        if (interceptedCalls.length == 1 && interceptedCalls[0].equals("")) {
+            interceptedCalls = new String[0];
+        }
+
+        // Create matchers for each expected call with flexible proxy matching
+        Matcher<String>[] matchers = new Matcher[expectedCalls.length];
+        for (int i = 0; i < expectedCalls.length; i++) {
+            matchers[i] = createFlexibleCallMatcher(expectedCalls[i]);
+        }
+
+        ec.checkThat(Arrays.asList(interceptedCalls), contains(matchers));
+    }
+
+    /**
+     * Creates a matcher that can handle flexible matching for proxy class names.
+     * For calls containing _groovyProxy, it matches the pattern ignoring numeric IDs before _groovyProxy.
+     * For other calls, it matches exactly.
+     */
+    private Matcher<String> createFlexibleCallMatcher(String expectedCall) {
+        if (expectedCall.contains("_groovyProxy")) {
+            String[] parts = expectedCall.split("_groovyProxy", 2);
+            String prefixWithNumber = parts[0];
+            String suffix = "_groovyProxy" + parts[1];
+            String prefix = prefixWithNumber.replaceAll("\\d+$", "");
+            String pattern = Pattern.quote(prefix) + "\\d+" + Pattern.quote(suffix);
+            return matchesPattern(pattern);
+        }
+        return equalTo(expectedCall);
+    }
+
+    /**
+     * Execute a Groovy expression both in and out of the sandbox and check that the return value matches the
+     * expected value.
+     * @param expression The Groovy expression to execute.
+     * @param expectedReturnValue The expected return value for running the script.
+     */
+    public void assertEvaluate(String expression, Object expectedReturnValue) {
+        sandboxedEval(expression, expectedReturnValue, e -> {
+            throw new RuntimeException("Failed to evaluate sandboxed expression: " + expression, e);
+        });
+        unsandboxedEval(expression, expectedReturnValue, e -> {
+            throw new RuntimeException("Failed to evaluate unsandboxed expression: " + expression, e);
+        });
+    }
+
+    /**
+     * Execute a Groovy expression both in and out of the sandbox and check that the script throws an exception with
+     * the same class and message in both cases.
+     * @param expression The Groovy expression to execute.
+     */
+    protected void assertFailsWithSameException(String expression) {
+        AtomicReference<Throwable> sandboxedException = new AtomicReference<>();
+        sandboxedEval(expression, ShouldFail.class, sandboxedException::set);
+        AtomicReference<Throwable> unsandboxedException = new AtomicReference<>();
+        unsandboxedEval(expression, ShouldFail.class, unsandboxedException::set);
+        if (sandboxedException.get() == null || unsandboxedException.get() == null) {
+            return; // Either sandboxedEval or unsandboxedEval will have already recorded an error because the result was not ShouldFail.
+        }
+        ec.checkThat("Sandboxed and unsandboxed exception should have the same type",
+                unsandboxedException.get().getClass(), equalTo(sandboxedException.get().getClass()));
+        ec.checkThat("Sandboxed and unsandboxed exception should have the same message",
+                unsandboxedException.get().getMessage(), equalTo(sandboxedException.get().getMessage()));
+    }
+}

--- a/src/test/java/org/kohsuke/groovy/sandbox/AbstractSandboxTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/AbstractSandboxTest.java
@@ -38,7 +38,7 @@ import org.kohsuke.groovy.sandbox.impl.GroovyCallSiteSelector;
 import org.hamcrest.Matcher;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.matchesPattern;
 
 /**
@@ -169,7 +169,7 @@ public abstract class AbstractSandboxTest {
             matchers[i] = createFlexibleCallMatcher(expectedCalls[i]);
         }
 
-        ec.checkThat(Arrays.asList(interceptedCalls), contains(matchers));
+        ec.checkThat("Actual calls: " + Arrays.toString(interceptedCalls), interceptedCalls, arrayContaining(matchers));
     }
 
     /**

--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -397,6 +397,23 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
     }
 
     @Issue("SECURITY-1754")
+    @Test public void blocksUnintendedCallsToNonSyntheticConstructors2() throws Exception {
+        sandboxedEval(
+                "class Base { }\n" +
+                "class Subclass extends Base { }\n" + // Subclass needed to break ties for specificity compared to ThisConstructorWrapper matching Object
+                "class Test {\n" +
+                "  Object tcw\n" +
+                "  Test(Object o) { this(o, o) }\n" +
+                "  Test(Object o, Subclass f) { tcw = o }\n" +
+                "}\n" +
+                "new Test(new Subclass()).tcw",
+                ShouldFail.class,
+                e -> assertThat(e.getMessage(), equalTo(
+                        "Rejecting unexpected invocation of constructor: public Test(java.lang.Object,Subclass). " +
+                        "Expected to invoke synthetic constructor: private Test(org.kohsuke.groovy.sandbox.impl.Checker$ThisConstructorWrapper,java.lang.Object)")));
+    }
+
+    @Issue("SECURITY-1754")
     @Test public void localVarsInIfStatementsAreNotInScopeInElseStatements() throws Exception {
         sandboxedEval(
                 "class Super { }\n" +
@@ -520,7 +537,7 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
                 Arrays.asList(1, 2, 3, "compareTo", "compareTo", "previous", "compareTo", "compareTo", "next", "compareTo", "compareTo", "next", "compareTo", "compareTo", "next", "compareTo", "compareTo", "next", "next"),
                 "new SandboxTransformerTest$OperatorOverloader(ArrayList,Integer)",
                 "new SandboxTransformerTest$OperatorOverloader(ArrayList,Integer)",
-                // These next 10 interceptions are from Checker.checkedRange and Checker.checkedComparison.
+                // These next 10 interceptions are from Checker.checkedCreateRange and Checker.checkedComparison.
                 "SandboxTransformerTest$OperatorOverloader.compareTo(SandboxTransformerTest$OperatorOverloader)",
                 "SandboxTransformerTest$OperatorOverloader.compareTo(SandboxTransformerTest$OperatorOverloader)",
                 "SandboxTransformerTest$OperatorOverloader.previous()",
@@ -856,12 +873,23 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
     @Test
     public void sandboxInterceptsAttributeExpressionsInPrefixPostfixOps() {
         assertIntercept(
-                "class Test { int x }\n" +
+                "class Test { int x; int y }\n" +
                 "def t = new Test()\n" +
-                "t.@x++\n" +
-                "t.@x\n",
-                1,
-                "new Test()", "Test.@x", "Integer.next()", "Test.@x=Integer", "Test.@x");
+                "def x1 = t.@x++ + 1\n" +
+                "def y1 = --t.@y - 1\n" +
+                "[t.@x, x1, t.@y, y1]\n",
+                Arrays.asList(1, 1, -1, -2),
+                "new Test()",
+                "Test.@x",
+                "Integer.next()",
+                "Test.@x=Integer",
+                "Integer.plus(Integer)",
+                "Test.@y",
+                "Integer.previous()",
+                "Test.@y=Integer",
+                "Integer.minus(Integer)",
+                "Test.@x",
+                "Test.@y");
     }
 
     @Test
@@ -954,6 +982,7 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
                 "[proxy.get(), proxy.get2()]",
                 Arrays.asList("overridden", "overridden"),
                 "new SandboxTransformerTest$AbstractClass()",
+                "new SandboxTransformerTest$AbstractClass(Integer)",
                 "SandboxTransformerTest$AbstractClass1_groovyProxy.get()",
                 "SandboxTransformerTest$AbstractClass1_groovyProxy.get2()");
         assertIntercept(
@@ -961,11 +990,16 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
                 "[proxy.get(), proxy.get2()]",
                 Arrays.asList("overridden", "default"),
                 "new SandboxTransformerTest$AbstractClass()",
+                "new SandboxTransformerTest$AbstractClass(Integer)",
                 "SandboxTransformerTest$AbstractClass1_groovyProxy.get()",
                 "SandboxTransformerTest$AbstractClass1_groovyProxy.get2()");
     }
 
     public static abstract class AbstractClass {
+        public AbstractClass() {}
+        public AbstractClass(int x) {
+            // Unused, but intercepted
+        }
         public abstract Object get();
         public Object get2() {
             return "default";
@@ -1159,6 +1193,82 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
                 "  }\n" +
                 "}\n" +
                 "new Test([:]).map\n");
+    }
+
+    @Test
+    public void spreadOperator() throws Exception {
+        assertIntercept(
+                "def list = ['a', null, 'bc']\n" +
+                "list*.length()",
+                Arrays.asList(1, null, 2),
+                "String.length()",
+                "String.length()");
+    }
+
+    @Test
+    public void directCallsToMethodsWithCheckedReplacements() {
+        assertIntercept(
+                "import org.codehaus.groovy.runtime.InvokerHelper\n" +
+                "def o = new SandboxTransformerTest$OperatorOverloader([], 2)\n" +
+                "[\n" +
+                "  InvokerHelper.bitwiseNegate(o),\n"+
+                "  InvokerHelper.unaryMinus(o),\n" +
+                "  InvokerHelper.unaryPlus(o)\n" +
+                "]\n",
+                Arrays.asList(-3, -2, 2),
+                "new SandboxTransformerTest$OperatorOverloader(ArrayList,Integer)",
+                "SandboxTransformerTest$OperatorOverloader.bitwiseNegate()",
+                "SandboxTransformerTest$OperatorOverloader.negative()",
+                "SandboxTransformerTest$OperatorOverloader.positive()");
+        assertIntercept(
+                "import org.codehaus.groovy.runtime.ScriptBytecodeAdapter\n" +
+                "def o = new SandboxTransformerTest$OperatorOverloader([], 3)\n" +
+                "[\n" +
+                "  ScriptBytecodeAdapter.bitwiseNegate(o),\n" +
+                "  ScriptBytecodeAdapter.unaryMinus(o),\n" +
+                "  ScriptBytecodeAdapter.unaryPlus(o)\n" +
+                "]\n",
+                Arrays.asList(-4, -3, 3),
+                "new SandboxTransformerTest$OperatorOverloader(ArrayList,Integer)",
+                "SandboxTransformerTest$OperatorOverloader.bitwiseNegate()",
+                "SandboxTransformerTest$OperatorOverloader.negative()",
+                "SandboxTransformerTest$OperatorOverloader.positive()");
+    }
+
+    @Test
+    public void switchStatementIntercepted() throws Exception {
+        assertIntercept(
+            "switch (String.valueOf(1)) {\n" +
+            "  case Integer:\n" +
+            "    return 'one'\n" +
+            "  case { it.length() == 2 }:\n" +
+            "    return 'two'\n" +
+            "  case ~/y/:\n" +
+            "    return 'three'\n" +
+            "  case Integer.&valueOf:\n" +
+            "    return 'four'\n" +
+            "}\n",
+            "four",
+            "String:valueOf(Integer)",
+            "String.length()",
+            "Integer.compareTo(Integer)",
+            "StringGroovyMethods:bitwiseNegate(String)",
+            "Integer:valueOf(String)");
+    }
+
+    @Test
+    public void whileLoopBodyIntercepted() throws Exception {
+        assertIntercept(
+            "def x = 0\n" +
+            "while (x < 1) {\n" +
+            "  x += 'abc'.length()\n" +
+            "}\n" +
+            "x",
+            3,
+            "Integer.compareTo(Integer)",
+            "String.length()",
+            "Integer.compareTo(Integer)"
+        );
     }
 
 }

--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -30,7 +30,6 @@ import groovy.lang.GroovyShell;
 import groovy.lang.IntRange;
 import groovy.lang.ObjectRange;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Files;
@@ -40,11 +39,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
-import org.codehaus.groovy.runtime.ProxyGeneratorAdapter;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -57,8 +55,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import org.hamcrest.Matcher;
 
 public class SandboxTransformerTest {
     public @Rule ErrorCollector ec = new ErrorCollector();
@@ -172,12 +173,37 @@ public class SandboxTransformerTest {
      * Check that the most recently executed expression intercepted the expected calls.
      * @param expectedCalls The method calls that were expected to be intercepted by the sandbox.
      */
+    @SuppressWarnings("unchecked")
     public void assertInterceptedExact(String... expectedCalls) {
         String[] interceptedCalls = cr.toString().split("\n");
         if (interceptedCalls.length == 1 && interceptedCalls[0].equals("")) {
             interceptedCalls = new String[0];
         }
-        ec.checkThat(interceptedCalls, equalTo(expectedCalls));
+
+        // Create matchers for each expected call with flexible proxy matching
+        Matcher<String>[] matchers = new Matcher[expectedCalls.length];
+        for (int i = 0; i < expectedCalls.length; i++) {
+            matchers[i] = createFlexibleCallMatcher(expectedCalls[i]);
+        }
+
+        ec.checkThat(Arrays.asList(interceptedCalls), contains(matchers));
+    }
+
+    /**
+     * Creates a matcher that can handle flexible matching for proxy class names.
+     * For calls containing _groovyProxy, it matches the pattern ignoring numeric IDs before _groovyProxy.
+     * For other calls, it matches exactly.
+     */
+    private Matcher<String> createFlexibleCallMatcher(String expectedCall) {
+        if (expectedCall.contains("_groovyProxy")) {
+            String[] parts = expectedCall.split("_groovyProxy", 2);
+            String prefixWithNumber = parts[0];
+            String suffix = "_groovyProxy" + parts[1];
+            String prefix = prefixWithNumber.replaceAll("\\d+$", "");
+            String pattern = Pattern.quote(prefix) + "\\d+" + Pattern.quote(suffix);
+            return matchesPattern(pattern);
+        }
+        return equalTo(expectedCall);
     }
 
     /**
@@ -1102,27 +1128,20 @@ public class SandboxTransformerTest {
 
     @Test
     public void sandboxInterceptsCastsToAbstractClasses() throws Throwable {
-        // Other tests that generate proxy classes will increment the counter.
-        // TODO: Could flake if tests are configured to run in parallel in the same JVM.
-        Field pxyCounterField = ProxyGeneratorAdapter.class.getDeclaredField("pxyCounter");
-        pxyCounterField.setAccessible(true);
-        AtomicLong pxyCounter = (AtomicLong) pxyCounterField.get(null);
-        long counter = pxyCounter.get() + 1;
         assertIntercept(
                 "def proxy = { -> 'overridden' } as org.kohsuke.groovy.sandbox.SandboxTransformerTest.AbstractClass\n" +
                 "[proxy.get(), proxy.get2()]",
                 Arrays.asList("overridden", "overridden"),
                 "new SandboxTransformerTest$AbstractClass()",
-                "SandboxTransformerTest$AbstractClass" + counter + "_groovyProxy.get()",
-                "SandboxTransformerTest$AbstractClass" + counter + "_groovyProxy.get2()");
-        counter = pxyCounter.get() + 1;
+                "SandboxTransformerTest$AbstractClass1_groovyProxy.get()",
+                "SandboxTransformerTest$AbstractClass1_groovyProxy.get2()");
         assertIntercept(
                 "def proxy = ['get': { -> 'overridden' }] as org.kohsuke.groovy.sandbox.SandboxTransformerTest.AbstractClass\n" +
                 "[proxy.get(), proxy.get2()]",
                 Arrays.asList("overridden", "default"),
                 "new SandboxTransformerTest$AbstractClass()",
-                "SandboxTransformerTest$AbstractClass" + counter + "_groovyProxy.get()",
-                "SandboxTransformerTest$AbstractClass" + counter + "_groovyProxy.get2()");
+                "SandboxTransformerTest$AbstractClass1_groovyProxy.get()",
+                "SandboxTransformerTest$AbstractClass1_groovyProxy.get2()");
     }
 
     public static abstract class AbstractClass {

--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -24,9 +24,7 @@
 
 package org.kohsuke.groovy.sandbox;
 
-import groovy.lang.Binding;
 import groovy.lang.EmptyRange;
-import groovy.lang.GroovyShell;
 import groovy.lang.IntRange;
 import groovy.lang.ObjectRange;
 import java.io.File;
@@ -39,206 +37,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
-import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.control.customizers.ImportCustomizer;
-import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ErrorCollector;
 import org.jvnet.hudson.test.Issue;
-import org.kohsuke.groovy.sandbox.impl.GroovyCallSiteSelector;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
-import org.hamcrest.Matcher;
 
-public class SandboxTransformerTest {
-    public @Rule ErrorCollector ec = new ErrorCollector();
-    public Binding binding = new Binding();
-    public GroovyShell sandboxedSh;
-    public GroovyShell unsandboxedSh;
-    public ClassRecorder cr = new ClassRecorder();
-
-    @Before
-    public void setUp() {
-        CompilerConfiguration cc = new CompilerConfiguration();
-        cc.addCompilationCustomizers(new ImportCustomizer().addImports(SandboxTransformerTest.class.getName()).addStarImports("org.kohsuke.groovy.sandbox"));
-        cc.addCompilationCustomizers(new SandboxTransformer());
-        sandboxedSh = new GroovyShell(binding,cc);
-
-        cc = new CompilerConfiguration();
-        cc.addCompilationCustomizers(new ImportCustomizer().addImports(SandboxTransformerTest.class.getName()).addStarImports("org.kohsuke.groovy.sandbox"));
-        unsandboxedSh = new GroovyShell(binding,cc);
-    }
-
-    public void configureBinding() { }
-
-    /**
-     * Use {@code ShouldFail.class} as the expected result for {@link #sandboxedEval} and {@link #unsandboxedEval}
-     * when the expression is expected to throw an exception.
-     */
-    public static final class ShouldFail { }
-
-    @FunctionalInterface
-    public interface ExceptionHandler {
-        public void handleException(Throwable e) throws Exception;
-    }
-
-    /**
-     * Executes a Groovy expression inside of the sandbox.
-     * @param expression The Groovy expression to execute.
-     */
-    public void sandboxedEval(String expression, Object expectedResult, ExceptionHandler handler) {
-        cr.reset();
-        cr.register();
-        try {
-            configureBinding();
-            Object actual = sandboxedSh.evaluate(expression);
-            String actualType = GroovyCallSiteSelector.getName(actual);
-            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
-            ec.checkThat("Sandboxed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
-        } catch (Throwable e) {
-            ec.checkSucceeds(() -> {
-                try {
-                    handler.handleException(e);
-                } catch (Throwable t) {
-                    t.addSuppressed(e); // Keep the original error around in case an assertion fails in the handler.
-                    throw t;
-                }
-                return null;
-            });
-        } finally {
-            cr.unregister();
-        }
-    }
-
-    /**
-     * Executes a Groovy expression outside of the sandbox.
-     * @param expression The Groovy expression to execute.
-     */
-    private void unsandboxedEval(String expression, Object expectedResult, ExceptionHandler handler) {
-        try {
-            configureBinding();
-            Object actual = unsandboxedSh.evaluate(expression);
-            String actualType = GroovyCallSiteSelector.getName(actual);
-            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
-            ec.checkThat("Unsandboxed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
-        } catch (Exception e) {
-            ec.checkSucceeds(() -> {
-                handler.handleException(e);
-                return null;
-            });
-        }
-    }
-
-    /**
-     * Execute a Groovy expression both in and out of the sandbox and check that the return value matches the
-     * expected value and that the given list of method calls are intercepted by the sandbox.
-     * @param expression The Groovy expression to execute.
-     * @param expectedReturnValue The expected return value for running the script.
-     * @param expectedCalls The method calls that are expected to be intercepted by the sandbox.
-     */
-    public void assertIntercept(String expression, Object expectedReturnValue, String... expectedCalls) {
-        assertEvaluate(expression, expectedReturnValue);
-        assertIntercepted(expectedCalls);
-    }
-
-    /**
-     * Check that the most recently executed expression intercepted the expected calls.
-     * Automatically adds {@code new Script(Binding)} to the list of intercepted calls.
-     * @param expectedCalls The method calls that were expected to be intercepted by the sandbox.
-     * @see #assertInterceptedExact
-     */
-    public void assertIntercepted(String... expectedCalls) {
-        // Workaround to avoid having to update all existing tests.
-        String[] updatedExpectedCalls = expectedCalls;
-        if (expectedCalls.length == 0 || (expectedCalls.length > 0 && !expectedCalls[0].equals("new Script(Binding)"))) {
-            updatedExpectedCalls = new String[expectedCalls.length + 1];
-            updatedExpectedCalls[0] = "new Script(Binding)";
-            System.arraycopy(expectedCalls, 0, updatedExpectedCalls, 1, expectedCalls.length);
-        }
-        assertInterceptedExact(updatedExpectedCalls);
-    }
-
-    /**
-     * Check that the most recently executed expression intercepted the expected calls.
-     * @param expectedCalls The method calls that were expected to be intercepted by the sandbox.
-     */
-    @SuppressWarnings("unchecked")
-    public void assertInterceptedExact(String... expectedCalls) {
-        String[] interceptedCalls = cr.toString().split("\n");
-        if (interceptedCalls.length == 1 && interceptedCalls[0].equals("")) {
-            interceptedCalls = new String[0];
-        }
-
-        // Create matchers for each expected call with flexible proxy matching
-        Matcher<String>[] matchers = new Matcher[expectedCalls.length];
-        for (int i = 0; i < expectedCalls.length; i++) {
-            matchers[i] = createFlexibleCallMatcher(expectedCalls[i]);
-        }
-
-        ec.checkThat(Arrays.asList(interceptedCalls), contains(matchers));
-    }
-
-    /**
-     * Creates a matcher that can handle flexible matching for proxy class names.
-     * For calls containing _groovyProxy, it matches the pattern ignoring numeric IDs before _groovyProxy.
-     * For other calls, it matches exactly.
-     */
-    private Matcher<String> createFlexibleCallMatcher(String expectedCall) {
-        if (expectedCall.contains("_groovyProxy")) {
-            String[] parts = expectedCall.split("_groovyProxy", 2);
-            String prefixWithNumber = parts[0];
-            String suffix = "_groovyProxy" + parts[1];
-            String prefix = prefixWithNumber.replaceAll("\\d+$", "");
-            String pattern = Pattern.quote(prefix) + "\\d+" + Pattern.quote(suffix);
-            return matchesPattern(pattern);
-        }
-        return equalTo(expectedCall);
-    }
-
-    /**
-     * Execute a Groovy expression both in and out of the sandbox and check that the return value matches the
-     * expected value.
-     * @param expression The Groovy expression to execute.
-     * @param expectedReturnValue The expected return value for running the script.
-     */
-    public void assertEvaluate(String expression, Object expectedReturnValue) {
-        sandboxedEval(expression, expectedReturnValue, e -> {
-            throw new RuntimeException("Failed to evaluate sandboxed expression: " + expression, e);
-        });
-        unsandboxedEval(expression, expectedReturnValue, e -> {
-            throw new RuntimeException("Failed to evaluate unsandboxed expression: " + expression, e);
-        });
-    }
-
-    /**
-     * Execute a Groovy expression both in and out of the sandbox and check that the script throws an exception with
-     * the same class and message in both cases.
-     * @param expression The Groovy expression to execute.
-     */
-    private void assertFailsWithSameException(String expression) {
-        AtomicReference<Throwable> sandboxedException = new AtomicReference<>();
-        sandboxedEval(expression, ShouldFail.class, sandboxedException::set);
-        AtomicReference<Throwable> unsandboxedException = new AtomicReference<>();
-        unsandboxedEval(expression, ShouldFail.class, unsandboxedException::set);
-        if (sandboxedException.get() == null || unsandboxedException.get() == null) {
-            return; // Either sandboxedEval or unsandboxedEval will have already recorded an error because the result was not ShouldFail.
-        }
-        ec.checkThat("Sandboxed and unsandboxed exception should have the same type",
-                unsandboxedException.get().getClass(), equalTo(sandboxedException.get().getClass()));
-        ec.checkThat("Sandboxed and unsandboxed exception should have the same message",
-                unsandboxedException.get().getMessage(), equalTo(sandboxedException.get().getMessage()));
-    }
+public class SandboxTransformerTest extends AbstractSandboxTest {
 
     @Issue("SECURITY-1465")
     @Test public void sandboxTransformsMethodPointerLhs() throws Exception {

--- a/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/SandboxTransformerTest.java
@@ -537,6 +537,17 @@ public class SandboxTransformerTest extends AbstractSandboxTest {
                 "SandboxTransformerTest$OperatorOverloader.value",
                 "ArrayList.add(Integer)",
                 "ArrayList.addAll(ArrayList)");
+        assertIntercept(
+                "def auditLog = []\n" +
+                "def list = (1..1).toList()\n" +
+                "def list2 = (1..<1).toList()\n" +
+                "[list, list2]",
+                Arrays.asList(Arrays.asList(1), Arrays.asList()),
+                "new IntRange(Boolean,Integer,Integer)",
+                "IntRange.toList()",
+                "Integer.compareTo(Integer)",
+                "new EmptyRange(Integer)",
+                "EmptyRange.toList()");
     }
 
     @Test public void unaryExpressionsSmoke() {

--- a/src/test/java/org/kohsuke/groovy/sandbox/TheTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/TheTest.java
@@ -1,17 +1,14 @@
 package org.kohsuke.groovy.sandbox;
 
 import org.codehaus.groovy.runtime.NullObject;
-import org.codehaus.groovy.runtime.ProxyGeneratorAdapter;
 import org.jvnet.hudson.test.Issue;
 import java.awt.Point;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicLong;
 import org.codehaus.groovy.runtime.ResourceGroovyMethods;
 import org.junit.Test;
 
@@ -736,10 +733,6 @@ public class TheTest extends SandboxTransformerTest {
 
     @Issue("SECURITY-566")
     @Test public void testTypeCoercion() throws Exception {
-        Field pxyCounterField = ProxyGeneratorAdapter.class.getDeclaredField("pxyCounter");
-        pxyCounterField.setAccessible(true);
-        AtomicLong pxyCounterValue = (AtomicLong) pxyCounterField.get(null);
-        pxyCounterValue.set(0); // make sure *_groovyProxy names are predictable
         assertIntercept("Locale:getDefault()/Class1_groovyProxy.getDefault()",
             Locale.getDefault(),
             "interface I {\n" +

--- a/src/test/java/org/kohsuke/groovy/sandbox/TheTest.java
+++ b/src/test/java/org/kohsuke/groovy/sandbox/TheTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Kohsuke Kawaguchi
  */
-public class TheTest extends SandboxTransformerTest {
+public class TheTest extends AbstractSandboxTest {
     @Override
     public void configureBinding() {
         binding.setProperty("foo", "FOO");


### PR DESCRIPTION
Each commit can be reviewed independently. 4a9c4e2cf91f3c1f2bc9068b5c7d08d3ba5b21ce and c920ac6bd1ab8ef4d6ea67e5841724478b61afea were largely done by an AI agent. I used VS code with the GitHub Copilot Chat extension in agent mode with Claude Sonnet 4 as the model.

4a9c4e2cf91f3c1f2bc9068b5c7d08d3ba5b21ce was done using the following initial prompt:

> Some of my tests are flaky when I try to run them concurrently because of static state in ProxyGeneratorAdapter. Can you adjust my test assertion methods like assertIntercept or assertInterceptExact to match proxy classes that end with _groovyProxy in a way that the exact numeric ID used by ProxyGeneratorAdapter does not matter, and then remove the reflection-related code in the relevant tests? All other interception should still be matched exactly. Thanks.

The agent more or less figured out what to do, but was trying to introduce new variants of `assertIntercept`, so I had to prompt a bit further to refine things. There was also some back-and-forth where the agent got pretty confused about regex escaping, but it was able to clean things up with some further prompting and suggestions of what approach to use.

c920ac6bd1ab8ef4d6ea67e5841724478b61afea was done using the following initial prompt:

> Can you please introduce an abstract superclass for `SandboxTransformerTest` and `TheTest` that has all of the utility methods and setup code from SandboxTransformerTest? Right now TheTest is running all of its tests as well as all of the tests from SandboxTransformerTest, so many of the tests are running twice for no reason

That more or less worked, but there were some missing imports. The agent wanted to reset `SandboxTransformerTest` using   git history and try again, but I stopped it and suggested that the problem might just be some missing imports, at which point it made the necessary changes successfully.

58d6069d3c372229b0c4ce15bef3115395bf3764 and 5df914c098b0816f0af3ade7818c9b5eaedebc36 were mostly done by me, although I used the agent to set up Pitest (https://pitest.org/). I asked the agent to summarize the Pitest report and indicate important cases where the test suite could be improved. The summary and suggestions were fine but not great.

I asked the agent to write some new tests to cover the gaps show by the mutation testing, and it was able to create new tests following the pattern of the existing one, but it went a bit too far and introduced a lot of redundant tests. For example, it tried to generate 6 new spread operator-related tests when all we really needed was one to cover the case of `null` in the list being spread over (e.g. `['a', null, 'ab']*.length()`). Interestingly, this specific case actually surfaced a bug in how `groovy-sandbox` handles `null` with the spread operator (doesn't really matter for Pipeline because spread method calls are not supported in CPS mode). It was interesting to see the agent check the expected results by running `groovy`, although it didn't notice on its own that our implementation had a bug. I tried getting the agent to refine the tests, but ultimately it was simpler to just do that on my own looking at the mutation testing report for interesting coverage gaps.

I did try to see if the agent could generate something like `blocksUnintendedCallsToNonSyntheticConstructors2`, and although it did try quite a lot of things, it never managed to trigger the critical case. This was not that surprising though to me - this case is pretty subtle, the logic is totally unique to our project, and it even took me a while to get the test right.

### Testing done

See above as well as new automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
